### PR TITLE
ci: install pre-commit inline instead of using the action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.x
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - run: python -m pip install pre-commit
+        shell: bash
+      - run: pre-commit run --all-files --show-diff-on-failure --color=always
+        shell: bash
 
   # Make sure commit messages follow the conventional commits convention:
   # https://www.conventionalcommits.org


### PR DESCRIPTION
### Description of change

Replaces the `pre-commit/action` step in the `lint` job with a direct `pip install pre-commit` followed by `pre-commit run --all-files`, removing the dependency on the third-party action. The `--show-diff-on-failure --color=always` flags preserve the diagnostic output the action previously provided.

The `pre-commit/action` repo does not pin its dependencies and closes every PR that attempts to update or pin them (e.g. https://github.com/pre-commit/action/pull/236). We don't want to keep maintaining a fork of the action just to get pinned dependencies, so we run pre-commit inline instead.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/esphome/esphome-glyphsets/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` - N/A
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".