### PR TITLE
ci: split release dry-run into its own job without elevated access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,40 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  release-dry-run:
+    needs:
+      - test
+      - lint
+      - commitlint
+
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+          submodules: true
+
+      - name: Checkout commit for release
+        run: |
+          git checkout -B ${{ github.ref_name }} ${{ github.sha }}
+
+      # Do a dry run of PSR
+      - name: Test release
+        uses: python-semantic-release/python-semantic-release@0dc72ac9058a62054a45f6344c83a423d7f906a8 # v9.21.1
+        with:
+          root_options: --noop
+          github_token: noop
+
   release:
     needs:
       - test
       - lint
       - commitlint
 
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release
     concurrency: release
@@ -86,19 +114,9 @@ jobs:
         run: |
           git checkout -B ${{ github.ref_name }} ${{ github.sha }}
 
-      # Do a dry run of PSR
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@0dc72ac9058a62054a45f6344c83a423d7f906a8 # v9.21.1
-        if: github.ref_name != 'main'
-        with:
-          root_options: --noop
-          github_token: noop
-
-      # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
         uses: python-semantic-release/python-semantic-release@0dc72ac9058a62054a45f6344c83a423d7f906a8 # v9.21.1
         id: release
-        if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Description of change

Splits the `release` job into two jobs so that pull requests no longer run with the `release` environment or write permissions.

- `release-dry-run` runs only on pull requests, with no `environment` and default (read-only) permissions, and performs the PSR `--noop` dry run.
- `release` runs only on pushes to `main`, keeping `environment: release` and the `id-token`/`attestations`/`contents` write permissions for the actual release and publish steps.

Previously the single `release` job ran on every PR with the elevated environment and permissions attached, even though it only did a dry run. The only cost of the split is a duplicated checkout step across the two jobs, which is unavoidable because `permissions` cannot be set conditionally within a single job.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/esphome/esphome-glyphsets/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` - N/A
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".